### PR TITLE
Fix single byte FrameV2 encoding

### DIFF
--- a/src/SerialAnalyzer.cpp
+++ b/src/SerialAnalyzer.cpp
@@ -232,7 +232,11 @@ void SerialAnalyzer::WorkerThread()
         mResults->AddFrame( frame );
 
         FrameV2 framev2;
-        framev2.AddInteger( "value", data );
+        if (mSettings->mBitsPerTransfer <= 8) {
+            framev2.AddByte( "value", data );
+        } else {
+            framev2.AddInteger( "value", data );
+        }
         framev2.AddBoolean( "parity_error", parity_error );
         framev2.AddBoolean( "framing_error", framing_error );
         framev2.AddBoolean( "address", mp_is_address );


### PR DESCRIPTION
Encodes single bytes as such in FrameV2 encoding so they are handled properly downstream. Once FrameV2 handles arbitrary length bytestrings we should switch to that.