### PR TITLE
useframev2

### DIFF
--- a/src/SerialAnalyzer.cpp
+++ b/src/SerialAnalyzer.cpp
@@ -6,6 +6,7 @@
 SerialAnalyzer::SerialAnalyzer() : Analyzer2(), mSettings( new SerialAnalyzerSettings() ), mSimulationInitilized( false )
 {
     SetAnalyzerSettings( mSettings.get() );
+    UseFrameV2();
 }
 
 SerialAnalyzer::~SerialAnalyzer()


### PR DESCRIPTION
This won't build until the new UseFrameV2(); Function has become an official part of the SDK. In the meantime, do not use `UseFrameV2();`, as it will fail to build.