### PR TITLE
Refactor and Enhance Codebase: Typo Fixes, README Improvements, Variable Cleanup, and Modernized Constructors

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Saleae Asynchronous Serial Analyzer
 
 ## Getting Started
 
-The following documentation describes getting this analyzer building locally. For more detailed information about the Analyzer SDK, debugging, CI build, and more, checkout the readme from the Sample Analyzer repository:
+The following documentation describes how to build this analyzer locally. For more detailed information about the Analyzer SDK, debugging, CI builds, and more, check out the readme in the Sample Analyzer repository.
 
 https://github.com/saleae/SampleAnalyzer
 
@@ -42,7 +42,7 @@ Building the analyzer:
 mkdir build
 cd build
 cmake ..
-cmake --build .
+cmake --build . # --config Release to build in release mode
 ```
 
 ### Ubuntu 18.04+
@@ -65,7 +65,7 @@ Building the analyzer:
 mkdir build
 cd build
 cmake ..
-cmake --build .
+cmake --build . # --config Release to build in release mode
 ```
 
 ### Windows
@@ -102,6 +102,7 @@ Building the analyzer:
 mkdir build
 cd build
 cmake .. -A x64
+cmake --build . # --config Release to build in release mode
 ```
 
 Then, open the newly created solution file located here: `build\serial_analyzer.sln`
@@ -119,11 +120,11 @@ For debug and release builds, respectively.
   
 ### Frame Type: `"data"`
 
-| Property | Type | Description |
-| :--- | :--- | :--- |
-| `data` | bytes | The serial word, the width in bits is controlled by the serial settings |
-| `error` | str | (optional) Present if an error was detected when decoding this word |
-| `address` | bool | (optional) Present if multi-processor or multi-drop bus special modes were selected. True indicates that this is an address byte |
+| Property  | Type  | Description                                                                                                                      |
+|:----------|:------|:---------------------------------------------------------------------------------------------------------------------------------|
+| `data`    | bytes | The serial word, the width in bits is controlled by the serial settings                                                          |
+| `error`   | str   | (optional) Present if an error was detected when decoding this word                                                              |
+| `address` | bool  | (optional) Present if multi-processor or multi-drop bus special modes were selected. True indicates that this is an address byte |
 
 A single serial word
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Saleae Asynchronous Serial Analyzer
 
-Saleae Asynchronous Serial Analyzer
-
 ## Getting Started
 
 The following documentation describes how to build this analyzer locally. For more detailed information about the Analyzer SDK, debugging, CI builds, and more, check out the readme in the Sample Analyzer repository.

--- a/src/SerialAnalyzer.cpp
+++ b/src/SerialAnalyzer.cpp
@@ -232,10 +232,10 @@ void SerialAnalyzer::WorkerThread()
         FrameV2 frameV2;
 
         U8 bytes[ 8 ];
-        for( int i = 0; i < bytes_per_transfer; ++i )
+        for( U32 i = 0; i < bytes_per_transfer; ++i )
         {
             auto bit_offset = ( bytes_per_transfer - i - 1 ) * 8;
-            bytes[ i ] = data >> bit_offset;
+            bytes[ i ] = (U8)(data >> bit_offset);
         }
         frameV2.AddByteArray( "data", bytes, bytes_per_transfer );
 

--- a/src/SerialAnalyzer.cpp
+++ b/src/SerialAnalyzer.cpp
@@ -211,8 +211,8 @@ void SerialAnalyzer::WorkerThread()
         // ok now record the value!
         // note that we're not using the mData2 or mType fields for anything, so we won't bother to set them.
         Frame frame;
-        frame.mStartingSampleInclusive = (S64)frame_starting_sample;
-        frame.mEndingSampleInclusive = (S64)mSerial->GetSampleNumber();
+        frame.mStartingSampleInclusive = ( S64 )frame_starting_sample;
+        frame.mEndingSampleInclusive = ( S64 )mSerial->GetSampleNumber();
         frame.mData1 = data;
         frame.mFlags = 0;
         if( parity_error == true )
@@ -235,7 +235,7 @@ void SerialAnalyzer::WorkerThread()
         for( U32 i = 0; i < bytes_per_transfer; ++i )
         {
             auto bit_offset = ( bytes_per_transfer - i - 1 ) * 8;
-            bytes[ i ] = (U8)(data >> bit_offset);
+            bytes[ i ] = ( U8 )( data >> bit_offset );
         }
         frameV2.AddByteArray( "data", bytes, bytes_per_transfer );
 

--- a/src/SerialAnalyzer.cpp
+++ b/src/SerialAnalyzer.cpp
@@ -3,7 +3,7 @@
 #include <AnalyzerChannelData.h>
 
 
-SerialAnalyzer::SerialAnalyzer() : Analyzer2(), mSettings( new SerialAnalyzerSettings() ), mSimulationInitilized( false )
+SerialAnalyzer::SerialAnalyzer() : Analyzer2(), mSettings( new SerialAnalyzerSettings() ), mSimulationInitialized( false )
 {
     SetAnalyzerSettings( mSettings.get() );
     UseFrameV2();
@@ -43,7 +43,7 @@ void SerialAnalyzer::ComputeSampleOffsets()
         1.0 ); // i.e. moving from the center of the last data bit (where we left off) to 1/2 period into the stop bit
 
     // and 1/2 bit before end of the stop bit period
-    mEndOfStopBitOffset = clock_generator.AdvanceByHalfPeriod( mSettings->mStopBits - 1.0 ); // if stopbits == 1.0, this will be 0
+    mEndOfStopBitOffset = clock_generator.AdvanceByHalfPeriod( mSettings->mStopBits - 1.0 ); // if stopBits == 1.0, this will be 0
 }
 
 
@@ -97,7 +97,7 @@ void SerialAnalyzer::WorkerThread()
 
     for( ;; )
     {
-        // we're starting high.  (we'll assume that we're not in the middle of a byte.
+        // we're starting high. (we'll assume that we're not in the middle of a byte.)
 
         mSerial->AdvanceToNextEdge();
 
@@ -180,7 +180,7 @@ void SerialAnalyzer::WorkerThread()
             mResults->AddMarker( marker_location, AnalyzerResults::Square, mSettings->mInputChannel );
         }
 
-        // now we must dermine if there is a framing error.
+        // now we must determine if there is a framing error.
         framing_error = false;
 
         mSerial->Advance( mStartOfStopBitOffset );
@@ -211,8 +211,8 @@ void SerialAnalyzer::WorkerThread()
         // ok now record the value!
         // note that we're not using the mData2 or mType fields for anything, so we won't bother to set them.
         Frame frame;
-        frame.mStartingSampleInclusive = frame_starting_sample;
-        frame.mEndingSampleInclusive = mSerial->GetSampleNumber();
+        frame.mStartingSampleInclusive = (S64)frame_starting_sample;
+        frame.mEndingSampleInclusive = (S64)mSerial->GetSampleNumber();
         frame.mData1 = data;
         frame.mFlags = 0;
         if( parity_error == true )
@@ -229,7 +229,7 @@ void SerialAnalyzer::WorkerThread()
 
         mResults->AddFrame( frame );
 
-        FrameV2 framev2;
+        FrameV2 frameV2;
 
         U8 bytes[ 8 ];
         for( int i = 0; i < bytes_per_transfer; ++i )
@@ -237,23 +237,23 @@ void SerialAnalyzer::WorkerThread()
             auto bit_offset = ( bytes_per_transfer - i - 1 ) * 8;
             bytes[ i ] = data >> bit_offset;
         }
-        framev2.AddByteArray( "data", bytes, bytes_per_transfer );
+        frameV2.AddByteArray( "data", bytes, bytes_per_transfer );
 
         if( parity_error )
         {
-            framev2.AddString( "error", "parity" );
+            frameV2.AddString( "error", "parity" );
         }
         else if( framing_error )
         {
-            framev2.AddString( "error", "framing" );
+            frameV2.AddString( "error", "framing" );
         }
 
         if( mSettings->mSerialMode != SerialAnalyzerEnums::Normal )
         {
-            framev2.AddBoolean( "address", mp_is_address );
+            frameV2.AddBoolean( "address", mp_is_address );
         }
 
-        mResults->AddFrameV2( framev2, "data", frame_starting_sample, mSerial->GetSampleNumber() );
+        mResults->AddFrameV2( frameV2, "data", frame_starting_sample, mSerial->GetSampleNumber() );
 
         mResults->CommitResults();
 
@@ -283,7 +283,7 @@ bool SerialAnalyzer::NeedsRerun()
     U32 computed_bit_rate = U32( double( mSampleRateHz ) / double( shortest_pulse ) );
 
     if( computed_bit_rate > mSampleRateHz )
-        AnalyzerHelpers::Assert( "Alg problem, computed_bit_rate is higer than sample rate" ); // just checking the obvious...
+        AnalyzerHelpers::Assert( "Alg problem, computed_bit_rate is higher than sample rate" ); // just checking the obvious...
 
     if( computed_bit_rate > ( mSampleRateHz / 4 ) )
         return false; // the baud rate is too fast.
@@ -312,10 +312,10 @@ bool SerialAnalyzer::NeedsRerun()
 U32 SerialAnalyzer::GenerateSimulationData( U64 minimum_sample_index, U32 device_sample_rate,
                                             SimulationChannelDescriptor** simulation_channels )
 {
-    if( mSimulationInitilized == false )
+    if( mSimulationInitialized == false )
     {
         mSimulationDataGenerator.Initialize( GetSimulationSampleRate(), mSettings.get() );
-        mSimulationInitilized = true;
+        mSimulationInitialized = true;
     }
 
     return mSimulationDataGenerator.GenerateSimulationData( minimum_sample_index, device_sample_rate, simulation_channels );

--- a/src/SerialAnalyzer.h
+++ b/src/SerialAnalyzer.h
@@ -34,7 +34,7 @@ class SerialAnalyzer : public Analyzer2
     AnalyzerChannelData* mSerial;
 
     SerialSimulationDataGenerator mSimulationDataGenerator;
-    bool mSimulationInitilized;
+    bool mSimulationInitialized;
 
     // Serial analysis vars:
     U32 mSampleRateHz;

--- a/src/SerialAnalyzer.h
+++ b/src/SerialAnalyzer.h
@@ -29,8 +29,8 @@ class SerialAnalyzer : public Analyzer2
     void ComputeSampleOffsets();
 
   protected: // vars
-    std::auto_ptr<SerialAnalyzerSettings> mSettings;
-    std::auto_ptr<SerialAnalyzerResults> mResults;
+    std::unique_ptr<SerialAnalyzerSettings> mSettings;
+    std::unique_ptr<SerialAnalyzerResults> mResults;
     AnalyzerChannelData* mSerial;
 
     SerialSimulationDataGenerator mSimulationDataGenerator;

--- a/src/SerialAnalyzerResults.cpp
+++ b/src/SerialAnalyzerResults.cpp
@@ -16,7 +16,7 @@ SerialAnalyzerResults::~SerialAnalyzerResults()
 }
 
 void SerialAnalyzerResults::GenerateBubbleText( U64 frame_index, Channel& /*channel*/,
-                                                DisplayBase display_base ) // unrefereced vars commented out to remove warnings.
+                                                DisplayBase display_base ) // unreferenced vars commented out to remove warnings.
 {
     // we only need to pay attention to 'channel' if we're making bubbles for more than one channel (as set by
     // AddChannelBubblesWillAppearOn)
@@ -258,14 +258,14 @@ void SerialAnalyzerResults::GenerateFrameTabularText( U64 frame_index, DisplayBa
 }
 
 void SerialAnalyzerResults::GeneratePacketTabularText( U64 /*packet_id*/,
-                                                       DisplayBase /*display_base*/ ) // unrefereced vars commented out to remove warnings.
+                                                       DisplayBase /*display_base*/ ) // unreferenced vars commented out to remove warnings.
 {
     ClearResultStrings();
     AddResultString( "not supported" );
 }
 
 void SerialAnalyzerResults::GenerateTransactionTabularText(
-    U64 /*transaction_id*/, DisplayBase /*display_base*/ ) // unrefereced vars commented out to remove warnings.
+    U64 /*transaction_id*/, DisplayBase /*display_base*/ ) // unreferenced vars commented out to remove warnings.
 {
     ClearResultStrings();
     AddResultString( "not supported" );

--- a/src/SerialAnalyzerResults.cpp
+++ b/src/SerialAnalyzerResults.cpp
@@ -11,8 +11,7 @@ SerialAnalyzerResults::SerialAnalyzerResults( SerialAnalyzer* analyzer, SerialAn
 {
 }
 
-SerialAnalyzerResults::~SerialAnalyzerResults()
-= default;
+SerialAnalyzerResults::~SerialAnalyzerResults() = default;
 
 void SerialAnalyzerResults::GenerateBubbleText( U64 frame_index, Channel& /*channel*/,
                                                 DisplayBase display_base ) // unreferenced vars commented out to remove warnings.
@@ -42,7 +41,6 @@ void SerialAnalyzerResults::GenerateBubbleText( U64 frame_index, Channel& /*chan
     // MP mode address case:
     if( ( frame.mFlags & MP_MODE_ADDRESS_FLAG ) != 0 )
     {
-
         AddResultString( "A" );
         AddResultString( "Addr" );
 
@@ -129,7 +127,7 @@ void SerialAnalyzerResults::GenerateExportFile( const char* file, DisplayBase di
 
             ss << std::endl;
 
-            AnalyzerHelpers::AppendToFile( ( U8* )ss.str().c_str(), (U32)ss.str().length(), f );
+            AnalyzerHelpers::AppendToFile( ( U8* )ss.str().c_str(), ( U32 )ss.str().length(), f );
             ss.str( std::string() );
 
             if( UpdateExportProgressAndCheckForCancel( i, num_frames ) == true )
@@ -179,7 +177,7 @@ void SerialAnalyzerResults::GenerateExportFile( const char* file, DisplayBase di
 
             ss << std::endl;
 
-            AnalyzerHelpers::AppendToFile( ( U8* )ss.str().c_str(), (U32)ss.str().length(), f );
+            AnalyzerHelpers::AppendToFile( ( U8* )ss.str().c_str(), ( U32 )ss.str().length(), f );
             ss.str( std::string() );
 
 
@@ -220,7 +218,6 @@ void SerialAnalyzerResults::GenerateFrameTabularText( U64 frame_index, DisplayBa
     // MP mode address case:
     if( ( frame.mFlags & MP_MODE_ADDRESS_FLAG ) != 0 )
     {
-
         if( framing_error == false )
         {
             snprintf( result_str, sizeof( result_str ), "Address: %s", number_str );

--- a/src/SerialAnalyzerResults.cpp
+++ b/src/SerialAnalyzerResults.cpp
@@ -4,7 +4,7 @@
 #include "SerialAnalyzerSettings.h"
 #include <iostream>
 #include <sstream>
-#include <stdio.h>
+
 
 SerialAnalyzerResults::SerialAnalyzerResults( SerialAnalyzer* analyzer, SerialAnalyzerSettings* settings )
     : AnalyzerResults(), mSettings( settings ), mAnalyzer( analyzer )
@@ -12,8 +12,7 @@ SerialAnalyzerResults::SerialAnalyzerResults( SerialAnalyzer* analyzer, SerialAn
 }
 
 SerialAnalyzerResults::~SerialAnalyzerResults()
-{
-}
+= default;
 
 void SerialAnalyzerResults::GenerateBubbleText( U64 frame_index, Channel& /*channel*/,
                                                 DisplayBase display_base ) // unreferenced vars commented out to remove warnings.
@@ -74,9 +73,9 @@ void SerialAnalyzerResults::GenerateBubbleText( U64 frame_index, Channel& /*chan
         snprintf( result_str, sizeof( result_str ), "%s (error)", number_str );
         AddResultString( result_str );
 
-        if( parity_error == true && framing_error == false )
+        if( framing_error == false )
             snprintf( result_str, sizeof( result_str ), "%s (parity error)", number_str );
-        else if( parity_error == false && framing_error == true )
+        else if( parity_error == false )
             snprintf( result_str, sizeof( result_str ), "%s (framing error)", number_str );
         else
             snprintf( result_str, sizeof( result_str ), "%s (framing error & parity error)", number_str );
@@ -238,9 +237,9 @@ void SerialAnalyzerResults::GenerateFrameTabularText( U64 frame_index, DisplayBa
     // normal case:
     if( ( parity_error == true ) || ( framing_error == true ) )
     {
-        if( parity_error == true && framing_error == false )
+        if( framing_error == false )
             snprintf( result_str, sizeof( result_str ), "%s (parity error)", number_str );
-        else if( parity_error == false && framing_error == true )
+        else if( parity_error == false )
             snprintf( result_str, sizeof( result_str ), "%s (framing error)", number_str );
         else
             snprintf( result_str, sizeof( result_str ), "%s (framing error & parity error)", number_str );

--- a/src/SerialAnalyzerResults.cpp
+++ b/src/SerialAnalyzerResults.cpp
@@ -41,10 +41,8 @@ void SerialAnalyzerResults::GenerateBubbleText( U64 frame_index, Channel& /*chan
     char result_str[ 128 ];
 
     // MP mode address case:
-    bool mp_mode_address_flag = false;
     if( ( frame.mFlags & MP_MODE_ADDRESS_FLAG ) != 0 )
     {
-        mp_mode_address_flag = true;
 
         AddResultString( "A" );
         AddResultString( "Addr" );
@@ -221,10 +219,8 @@ void SerialAnalyzerResults::GenerateFrameTabularText( U64 frame_index, DisplayBa
     char result_str[ 128 ];
 
     // MP mode address case:
-    bool mp_mode_address_flag = false;
     if( ( frame.mFlags & MP_MODE_ADDRESS_FLAG ) != 0 )
     {
-        mp_mode_address_flag = true;
 
         if( framing_error == false )
         {

--- a/src/SerialAnalyzerResults.cpp
+++ b/src/SerialAnalyzerResults.cpp
@@ -130,7 +130,7 @@ void SerialAnalyzerResults::GenerateExportFile( const char* file, DisplayBase di
 
             ss << std::endl;
 
-            AnalyzerHelpers::AppendToFile( ( U8* )ss.str().c_str(), ss.str().length(), f );
+            AnalyzerHelpers::AppendToFile( ( U8* )ss.str().c_str(), (U32)ss.str().length(), f );
             ss.str( std::string() );
 
             if( UpdateExportProgressAndCheckForCancel( i, num_frames ) == true )
@@ -180,7 +180,7 @@ void SerialAnalyzerResults::GenerateExportFile( const char* file, DisplayBase di
 
             ss << std::endl;
 
-            AnalyzerHelpers::AppendToFile( ( U8* )ss.str().c_str(), ss.str().length(), f );
+            AnalyzerHelpers::AppendToFile( ( U8* )ss.str().c_str(), (U32)ss.str().length(), f );
             ss.str( std::string() );
 
 

--- a/src/SerialAnalyzerSettings.cpp
+++ b/src/SerialAnalyzerSettings.cpp
@@ -25,7 +25,7 @@ SerialAnalyzerSettings::SerialAnalyzerSettings()
     mBitRateInterface->SetTitleAndTooltip( "Bit Rate (Bits/s)", "Specify the bit rate in bits per second." );
     mBitRateInterface->SetMax( 100000000 );
     mBitRateInterface->SetMin( 1 );
-    mBitRateInterface->SetInteger( mBitRate );
+    mBitRateInterface->SetInteger( (int)mBitRate );
 
     mUseAutobaudInterface.reset( new AnalyzerSettingInterfaceBool() );
     mUseAutobaudInterface->SetTitleAndTooltip(
@@ -151,7 +151,7 @@ bool SerialAnalyzerSettings::SetSettingsFromInterfaces()
 void SerialAnalyzerSettings::UpdateInterfacesFromSettings()
 {
     mInputChannelInterface->SetChannel( mInputChannel );
-    mBitRateInterface->SetInteger( mBitRate );
+    mBitRateInterface->SetInteger( (int)mBitRate );
     mBitsPerTransferInterface->SetNumber( mBitsPerTransfer );
     mStopBitsInterface->SetNumber( mStopBits );
     mParityInterface->SetNumber( mParity );

--- a/src/SerialAnalyzerSettings.cpp
+++ b/src/SerialAnalyzerSettings.cpp
@@ -25,7 +25,7 @@ SerialAnalyzerSettings::SerialAnalyzerSettings()
     mBitRateInterface->SetTitleAndTooltip( "Bit Rate (Bits/s)", "Specify the bit rate in bits per second." );
     mBitRateInterface->SetMax( 100000000 );
     mBitRateInterface->SetMin( 1 );
-    mBitRateInterface->SetInteger( (int)mBitRate );
+    mBitRateInterface->SetInteger( ( int )mBitRate );
 
     mUseAutobaudInterface.reset( new AnalyzerSettingInterfaceBool() );
     mUseAutobaudInterface->SetTitleAndTooltip(
@@ -119,8 +119,7 @@ SerialAnalyzerSettings::SerialAnalyzerSettings()
     AddChannel( mInputChannel, "Serial", false );
 }
 
-SerialAnalyzerSettings::~SerialAnalyzerSettings()
-= default;
+SerialAnalyzerSettings::~SerialAnalyzerSettings() = default;
 
 bool SerialAnalyzerSettings::SetSettingsFromInterfaces()
 {
@@ -150,7 +149,7 @@ bool SerialAnalyzerSettings::SetSettingsFromInterfaces()
 void SerialAnalyzerSettings::UpdateInterfacesFromSettings()
 {
     mInputChannelInterface->SetChannel( mInputChannel );
-    mBitRateInterface->SetInteger( (int)mBitRate );
+    mBitRateInterface->SetInteger( ( int )mBitRate );
     mBitsPerTransferInterface->SetNumber( mBitsPerTransfer );
     mStopBitsInterface->SetNumber( mStopBits );
     mParityInterface->SetNumber( mParity );

--- a/src/SerialAnalyzerSettings.cpp
+++ b/src/SerialAnalyzerSettings.cpp
@@ -120,8 +120,7 @@ SerialAnalyzerSettings::SerialAnalyzerSettings()
 }
 
 SerialAnalyzerSettings::~SerialAnalyzerSettings()
-{
-}
+= default;
 
 bool SerialAnalyzerSettings::SetSettingsFromInterfaces()
 {

--- a/src/SerialAnalyzerSettings.cpp
+++ b/src/SerialAnalyzerSettings.cpp
@@ -179,8 +179,8 @@ void SerialAnalyzerSettings::LoadSettings( const char* settings )
     text_archive >> *( U32* )&mShiftOrder;
     text_archive >> mInverted;
 
-    // check to make sure loading it actual works before assigning the result -- do this when adding settings to an analyzer which has been
-    // previously released.
+    // check to make sure loading it actually works before assigning the result
+    // do this when adding settings to an analyzer which has been previously released.
     bool use_autobaud;
     if( text_archive >> use_autobaud )
         mUseAutobaud = use_autobaud;

--- a/src/SerialAnalyzerSettings.cpp
+++ b/src/SerialAnalyzerSettings.cpp
@@ -179,7 +179,7 @@ void SerialAnalyzerSettings::LoadSettings( const char* settings )
     text_archive >> *( U32* )&mShiftOrder;
     text_archive >> mInverted;
 
-    // check to make sure loading it actual works befor assigning the result -- do this when adding settings to an anylzer which has been
+    // check to make sure loading it actual works before assigning the result -- do this when adding settings to an analyzer which has been
     // previously released.
     bool use_autobaud;
     if( text_archive >> use_autobaud )

--- a/src/SerialAnalyzerSettings.h
+++ b/src/SerialAnalyzerSettings.h
@@ -37,15 +37,15 @@ class SerialAnalyzerSettings : public AnalyzerSettings
     SerialAnalyzerEnums::Mode mSerialMode;
 
   protected:
-    std::auto_ptr<AnalyzerSettingInterfaceChannel> mInputChannelInterface;
-    std::auto_ptr<AnalyzerSettingInterfaceInteger> mBitRateInterface;
-    std::auto_ptr<AnalyzerSettingInterfaceNumberList> mBitsPerTransferInterface;
-    std::auto_ptr<AnalyzerSettingInterfaceNumberList> mShiftOrderInterface;
-    std::auto_ptr<AnalyzerSettingInterfaceNumberList> mStopBitsInterface;
-    std::auto_ptr<AnalyzerSettingInterfaceNumberList> mParityInterface;
-    std::auto_ptr<AnalyzerSettingInterfaceNumberList> mInvertedInterface;
-    std::auto_ptr<AnalyzerSettingInterfaceBool> mUseAutobaudInterface;
-    std::auto_ptr<AnalyzerSettingInterfaceNumberList> mSerialModeInterface;
+    std::unique_ptr<AnalyzerSettingInterfaceChannel> mInputChannelInterface;
+    std::unique_ptr<AnalyzerSettingInterfaceInteger> mBitRateInterface;
+    std::unique_ptr<AnalyzerSettingInterfaceNumberList> mBitsPerTransferInterface;
+    std::unique_ptr<AnalyzerSettingInterfaceNumberList> mShiftOrderInterface;
+    std::unique_ptr<AnalyzerSettingInterfaceNumberList> mStopBitsInterface;
+    std::unique_ptr<AnalyzerSettingInterfaceNumberList> mParityInterface;
+    std::unique_ptr<AnalyzerSettingInterfaceNumberList> mInvertedInterface;
+    std::unique_ptr<AnalyzerSettingInterfaceBool> mUseAutobaudInterface;
+    std::unique_ptr<AnalyzerSettingInterfaceNumberList> mSerialModeInterface;
 };
 
 #endif // SERIAL_ANALYZER_SETTINGS

--- a/src/SerialAnalyzerSettings.h
+++ b/src/SerialAnalyzerSettings.h
@@ -12,7 +12,7 @@ namespace SerialAnalyzerEnums
         MpModeMsbZeroMeansAddress,
         MpModeMsbOneMeansAddress
     };
-};
+}
 
 class SerialAnalyzerSettings : public AnalyzerSettings
 {

--- a/src/SerialSimulationDataGenerator.cpp
+++ b/src/SerialSimulationDataGenerator.cpp
@@ -1,11 +1,9 @@
 #include "SerialSimulationDataGenerator.h"
 #include "SerialAnalyzerSettings.h"
 
-SerialSimulationDataGenerator::SerialSimulationDataGenerator()
-= default;
+SerialSimulationDataGenerator::SerialSimulationDataGenerator() = default;
 
-SerialSimulationDataGenerator::~SerialSimulationDataGenerator()
-= default;
+SerialSimulationDataGenerator::~SerialSimulationDataGenerator() = default;
 
 void SerialSimulationDataGenerator::Initialize( U32 simulation_sample_rate, SerialAnalyzerSettings* settings )
 {

--- a/src/SerialSimulationDataGenerator.cpp
+++ b/src/SerialSimulationDataGenerator.cpp
@@ -2,12 +2,10 @@
 #include "SerialAnalyzerSettings.h"
 
 SerialSimulationDataGenerator::SerialSimulationDataGenerator()
-{
-}
+= default;
 
 SerialSimulationDataGenerator::~SerialSimulationDataGenerator()
-{
-}
+= default;
 
 void SerialSimulationDataGenerator::Initialize( U32 simulation_sample_rate, SerialAnalyzerSettings* settings )
 {
@@ -75,7 +73,7 @@ U32 SerialSimulationDataGenerator::GenerateSimulationData( U64 largest_sample_re
             {
                 mSerialSimulationData.Advance( mClockGenerator.AdvanceByHalfPeriod( 2.0 ) ); // insert 2 bit-periods of idle
                 CreateSerialByte( ( mValue++ & mNumBitsMask ) | mMpModeDataMask );
-            };
+            }
 
             mSerialSimulationData.Advance( mClockGenerator.AdvanceByHalfPeriod( 20.0 ) ); // insert 20 bit-periods of idle
 
@@ -86,7 +84,7 @@ U32 SerialSimulationDataGenerator::GenerateSimulationData( U64 largest_sample_re
             {
                 mSerialSimulationData.Advance( mClockGenerator.AdvanceByHalfPeriod( 2.0 ) ); // insert 2 bit-periods of idle
                 CreateSerialByte( ( mValue++ & mNumBitsMask ) | mMpModeDataMask );
-            };
+            }
 
             mSerialSimulationData.Advance( mClockGenerator.AdvanceByHalfPeriod( 20.0 ) ); // insert 20 bit-periods of idle
         }

--- a/src/SerialSimulationDataGenerator.cpp
+++ b/src/SerialSimulationDataGenerator.cpp
@@ -141,6 +141,6 @@ void SerialSimulationDataGenerator::CreateSerialByte( U64 value )
 
     mSerialSimulationData.TransitionIfNeeded( mBitHigh ); // we need to end high
 
-    // lets pad the end a bit for the stop bit:
+    // let's pad the end a bit for the stop bit:
     mSerialSimulationData.Advance( mClockGenerator.AdvanceByHalfPeriod( mSettings->mStopBits ) );
 }

--- a/src/SerialSimulationDataGenerator.h
+++ b/src/SerialSimulationDataGenerator.h
@@ -12,7 +12,7 @@ class SerialSimulationDataGenerator
     ~SerialSimulationDataGenerator();
 
     void Initialize( U32 simulation_sample_rate, SerialAnalyzerSettings* settings );
-    U32 GenerateSimulationData( U64 newest_sample_requested, U32 sample_rate, SimulationChannelDescriptor** simulation_channelss );
+    U32 GenerateSimulationData( U64 newest_sample_requested, U32 sample_rate, SimulationChannelDescriptor** simulation_channels );
 
   protected:
     SerialAnalyzerSettings* mSettings;
@@ -30,4 +30,4 @@ class SerialSimulationDataGenerator
     ClockGenerator mClockGenerator;
     SimulationChannelDescriptor mSerialSimulationData; // if we had more than one channel to simulate, they would need to be in an array
 };
-#endif // UNIO_SIMULATION_DATA_GENERATOR
+#endif // SERIAL_SIMULATION_DATA_GENERATOR


### PR DESCRIPTION
Fixed typos
Improved README
Removed useless variables
Fixed variables signedness
Removed deprecated features
Now using '= default' for trivial constructors and destructors