### PR TITLE
Testing: update github actions.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,20 +12,20 @@ jobs:
   windows:
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Build
       run: |
         cmake -B ${{github.workspace}}/build -A x64
         cmake --build ${{github.workspace}}/build --config Release
     - name: Upload windows build
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: windows
         path: ${{github.workspace}}/build/Analyzers/Release/*.dll
   macos:
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Build
       run: |
         cmake -B ${{github.workspace}}/build/x86_64 -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_ARCHITECTURES=x86_64
@@ -33,19 +33,19 @@ jobs:
         cmake -B ${{github.workspace}}/build/arm64 -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_ARCHITECTURES=arm64
         cmake --build ${{github.workspace}}/build/arm64
     - name: Upload MacOS x86_64 build
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: macos_x86_64
         path: ${{github.workspace}}/build/x86_64/Analyzers/*.so
     - name: Upload MacOS arm64 build
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: macos_arm64
         path: ${{github.workspace}}/build/arm64/Analyzers/*.so
   linux:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Build
       run: |
         cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Release
@@ -54,7 +54,7 @@ jobs:
         CC:   gcc-10
         CXX:  g++-10
     - name: Upload Linux build
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: linux
         path: ${{github.workspace}}/build/Analyzers/*.so
@@ -63,14 +63,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: download individual builds
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         path: ${{github.workspace}}/artifacts
     - name: zip
       run: |
         cd ${{github.workspace}}/artifacts
         zip -r ${{github.workspace}}/analyzer.zip .
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: all-platforms
         path: ${{github.workspace}}/artifacts/**


### PR DESCRIPTION
addresses this CI warning:
```
The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2, actions/upload-artifact@v2. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
```

This is a test PR. If these changes are accepted, we will close this PR and roll this change out to all analyzers automatically.

updated actions:
actions/checkout
actions/upload-artifact
actions/download-artifact

updates from V2 to V3. Only notable change is that these now use node16. Github actions runners are showing warnings for node 12 usage.